### PR TITLE
Un-revert Bitcoin Core "Fix the StartupWMClass for bitoin-qt, ..."

### DIFF
--- a/debian/bitcoin-qt.desktop
+++ b/debian/bitcoin-qt.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Encoding=UTF-8
+Version=1.0
 Name=Bitcoin Core
 Comment=Connect to the Bitcoin P2P Network
 Comment[de]=Verbinde mit dem Bitcoin peer-to-peer Netzwerk
@@ -11,3 +11,4 @@ Type=Application
 Icon=bitcoin128
 MimeType=x-scheme-handler/bitcoin;
 Categories=Office;Finance;P2P;Network;Qt;
+Encoding=UTF-8


### PR DESCRIPTION
80528b12012a8e86818ccd3a65a9c4ef3ca485e8 accidentally reverted
Bitcoin Core merge f0c1f8abb0182da557d07372b938f3a0a4bb906f as it
overwrote the debian directory with the PPA version.