### PR TITLE
debian: Add copyright info for proxy icon in statusbar

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -93,6 +93,11 @@ Copyright: Bitboy, Jonas Schnelli
 License: public-domain
 Comment: Site: https://bitcointalk.org/?topic=1756.0
 
+Files: src/qt/res/icons/proxy.png
+       src/qt/res/src/proxy.svg
+Copyright: Cristian Mircea Messel
+Licese: public-domain
+
 
 License: Expat
  Permission is hereby granted, free of charge, to any person obtaining a


### PR DESCRIPTION
This seems to have been lost somewhere