### PR TITLE
snap: Clarify datadir location in comment

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,9 +16,9 @@ apps:
     command: bitcoind
     plugs: [network, network-bind]
     environment:
-      # Override HOME so the bitcoin datadir is located at
-      # ~/snap/bitcoin/common/.bitcoin instead of
-      # ~/snap/bitcoin/current/.bitcoin, and each new version of the bitcoin
+      # Override HOME so the datadir is located at
+      # ~/snap/bitcoin-core/common/.bitcoin/ instead of
+      # ~/snap/bitcoin-core/current/.bitcoin/, and each new version of the
       # snap won't have a different data directory:
       # https://docs.snapcraft.io/environment-variables/7983
       HOME: $SNAP_USER_COMMON


### PR DESCRIPTION
The snap was renamed from `bitcoin` to `bitcoin-core`. See also https://github.com/bitcoin-core/packaging/issues/21#issuecomment-506528859