### PR TITLE
snap: Remove gpg check at build time

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,8 +42,6 @@ parts:
       wget https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/SHA256SUMS.asc
       wget https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}.tar.gz
       wget https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
-      gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 01EA5486DE18A882D4C2684590C8019E36C2E964
-      gpg --verify SHA256SUMS.asc
       echo "d0a385d05a89c611caa7fea6ae561e01249f2df51212a267fb65b361d49365f7  SHA256SUMS.asc" | sha256sum --check
       sha256sum --ignore-missing --check SHA256SUMS.asc
       tar -xvf bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz


### PR DESCRIPTION
The check passes locally and remotely on travis. E.g. https://travis-ci.org/MarcoFalke/packaging/builds/569334266#L3287

However, the key import no longer works on the launchpad architecture for some unknown reason.
See https://code.launchpad.net/~bitcoin-core/+snap/bitcoin-core-snap-master:

* https://code.launchpad.net/~bitcoin-core/+snap/bitcoin-core-snap-master/+build/640145/+files/buildlog_snap_ubuntu_xenial_arm64_bitcoin-core-snap-master_BUILDING.txt.gz
* https://code.launchpad.net/~bitcoin-core/+snap/bitcoin-core-snap-master/+build/640144/+files/buildlog_snap_ubuntu_xenial_armhf_bitcoin-core-snap-master_BUILDING.txt.gz
* https://code.launchpad.net/~bitcoin-core/+snap/bitcoin-core-snap-master/+build/640143/+files/buildlog_snap_ubuntu_xenial_amd64_bitcoin-core-snap-master_BUILDING.txt.gz
* https://code.launchpad.net/~bitcoin-core/+snap/bitcoin-core-snap-master/+build/640130/+files/buildlog_snap_ubuntu_xenial_arm64_bitcoin-core-snap-master_BUILDING.txt.gz
* https://code.launchpad.net/~bitcoin-core/+snap/bitcoin-core-snap-master/+build/640129/+files/buildlog_snap_ubuntu_xenial_armhf_bitcoin-core-snap-master_BUILDING.txt.gz
* https://code.launchpad.net/~bitcoin-core/+snap/bitcoin-core-snap-master/+build/640128/+files/buildlog_snap_ubuntu_xenial_amd64_bitcoin-core-snap-master_BUILDING.txt.gz

Fix the build error, which is hard to debug remotely and not reproducible locally, by removing the gpg check. This should be fine, as we trust the Ubuntu launchpad architecture anyway to build and deliver the correct package to users.

The shasum check is still in place to protect against obvious errors and advanced users are encouraged to and might be able to verify the shasum themselves.