### PR TITLE
Added the unity7 plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ confinement: strict
 apps:
   daemon:
     command: bitcoind
-    plugs: [removable-media, network, network-bind]
+    plugs: [home, removable-media, network, network-bind]
     environment:
       # Override HOME so the datadir is located at
       # ~/snap/bitcoin-core/common/.bitcoin/ instead of
@@ -24,13 +24,13 @@ apps:
       HOME: $SNAP_USER_COMMON
   qt:
     command: desktop-launch bitcoin-qt
-    plugs: [removable-media, network, network-bind, desktop, x11]
+    plugs: [home, removable-media, network, network-bind, desktop, x11, unity7]
     environment:
       HOME: $SNAP_USER_COMMON
       DISABLE_WAYLAND: 1
   cli:
     command: bitcoin-cli
-    plugs: [removable-media, network]
+    plugs: [home, removable-media, network]
     environment:
       HOME: $SNAP_USER_COMMON
 


### PR DESCRIPTION
Hi @MarcoFalke 

The Bitcoin-core wallet GUI does not display the tray menu because the snap package does not have the plugin's tray access permission.
![image](https://user-images.githubusercontent.com/12465465/101350193-9ffc4e00-389f-11eb-8c0e-9bd15f53b3e6.png)


 The Unity7 plug will solve this problem.

see snapcraft [isssue](https://forum.snapcraft.io/t/system-tray-icon-only-works-in-devmode-qt-5/7126)