### PR TITLE
Bump to bionic (core18) and add bitcoin-tx bitcoin-wallet and bitcoin-util binaries

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: bitcoin-core
-version: 22.0
+version: '22.0'
 summary:   peer-to-peer network based digital currency
 description: |
   Bitcoin is a free open source peer-to-peer electronic cash system that
@@ -10,6 +10,7 @@ description: |
 
 grade: stable
 confinement: strict
+base: core18
 
 apps:
   daemon:
@@ -35,6 +36,36 @@ apps:
       HOME: $SNAP_USER_COMMON
 
 parts:
+  # Needed to supply desktop-launch
+  # Paste from https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml
+  # Boilerplate seems to be required according to https://bugs.launchpad.net/snapcraft/+bug/1800057
+  desktop-qt5:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-depth: 1
+    source-subdir: qt
+    source-commit: ec861254c2a1d2447b2c589446e6cdf04c75c260
+    plugin: make
+    make-parameters: ["FLAVOR=qt5"]
+    build-packages:
+      - build-essential
+      - qtbase5-dev
+      - dpkg-dev
+    stage-packages:
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libqt5gui5
+      - libgdk-pixbuf2.0-0
+      - libqt5svg5 # for loading icon themes which are svg
+      - try: [appmenu-qt5] # not available on core18
+      - locales-all
+      - xdg-user-dirs
+      - fcitx-frontend-qt5
+
   bitcoin-core:
     plugin: nil
     override-build: | 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,19 @@ apps:
     plugs: [home, removable-media, network]
     environment:
       HOME: $SNAP_USER_COMMON
+  tx:
+    command: bitcoin-tx
+    environment:
+      HOME: $SNAP_USER_COMMON
+  wallet:
+    command: bitcoin-wallet
+    plugs: [home, removable-media]
+    environment:
+      HOME: $SNAP_USER_COMMON
+  util:
+    command: bitcoin-util
+    environment:
+      HOME: $SNAP_USER_COMMON
 
 parts:
   # Needed to supply desktop-launch
@@ -82,6 +95,9 @@ parts:
       install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoind
       install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-qt
       install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-cli
+      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-tx
+      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-wallet
+      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-util
       wget https://raw.githubusercontent.com/bitcoin/bitcoin/v${SNAPCRAFT_PROJECT_VERSION}/share/pixmaps/bitcoin128.png
       install -m 0644 -D -t $SNAPCRAFT_PART_INSTALL/share/pixmaps bitcoin128.png
     build-packages:


### PR DESCRIPTION
Since core16 was deprecated, this PR updates to bionic (core18) as base, for this update I followed some guidance of the staled PRs referenced at https://github.com/bitcoin-core/packaging/issues/65. I've built with snapcraft 6.1 and it seemd to work properly.

I'm also exposing the bitcoin-tx, bitcoin-wallet and bitcoin-util binaries as requested in https://github.com/bitcoin-core/packaging/issues/72.