### PR TITLE
snap: core20 (with ci)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,16 +1,16 @@
 task:
   use_compute_credits: true
-  container:
-    image: ubuntu:18.04
+  compute_engine_instance:  # https://cirrus-ci.org/guide/custom-vms/#custom-compute-engine-vms
+    image_project: ubuntu-os-cloud
+    image: family/ubuntu-2404-lts-amd64  # https://cloud.google.com/compute/docs/images/os-details#ubuntu_lts
     cpu: 1
     memory: 2G
   timeout_in: 20m
-  env:
-    DOCKER_PACKAGES: "snapcraft"
   install_packages_script:
-    - apt-get update
-    - apt-get install --no-install-recommends --no-upgrade -qq $DOCKER_PACKAGES
+    - snap install snapcraft --classic
+    - snap install lxd
+    - /snap/bin/lxd init --auto
   snapcraft_pull_script:
-    - snapcraft pull
+    - snapcraft pull --use-lxd
   ci_script:
-    - snapcraft
+    - snapcraft --use-lxd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,11 +8,11 @@ description: |
 
 grade: stable
 confinement: strict
-base: core18
+base: core20
 
 apps:
   daemon:
-    command: bitcoind
+    command: bin/bitcoind
     plugs: [home, removable-media, network, network-bind]
     environment:
       # Override HOME so the datadir is located at
@@ -22,27 +22,27 @@ apps:
       # https://docs.snapcraft.io/environment-variables/7983
       HOME: $SNAP_USER_COMMON
   qt:
-    command: desktop-launch bitcoin-qt
+    command: bin/desktop-launch bin/bitcoin-qt
     plugs: [home, removable-media, network, network-bind, desktop, x11, unity7]
     environment:
       HOME: $SNAP_USER_COMMON
       DISABLE_WAYLAND: 1
   cli:
-    command: bitcoin-cli
+    command: bin/bitcoin-cli
     plugs: [home, removable-media, network]
     environment:
       HOME: $SNAP_USER_COMMON
   tx:
-    command: bitcoin-tx
+    command: bin/bitcoin-tx
     environment:
       HOME: $SNAP_USER_COMMON
   wallet:
-    command: bitcoin-wallet
+    command: bin/bitcoin-wallet
     plugs: [home, removable-media]
     environment:
       HOME: $SNAP_USER_COMMON
   util:
-    command: bitcoin-util
+    command: bin/bitcoin-util
     environment:
       HOME: $SNAP_USER_COMMON
 


### PR DESCRIPTION
The `core18` builder is insufficient, now that glibc in the release builds was bumped (https://github.com/bitcoin/bitcoin/pull/29987).

Fix it by bumping to `core20`, because `core18` is also deprecated and only available in the snapcraft `7.x` track according to https://snapcraft.io/docs/base-snaps#core18.

The change comes with required fixups in the `snapcraft.yaml`.

This change also comes with a required switch to lxd in the CI. This is, because "For core20, Multipass is the default provider on all platforms.", according to https://canonical-snapcraft.readthedocs-hosted.com/en/latest/howto/select-a-build-provider/#core20-override-methods. However, multipass by default uses a QEMU KVM driver, according to https://canonical.com/multipass/docs/driver#p-74200-default-drivers. So just use lxd in the CI, as KVM isn't available.