### PR TITLE
snap: path to bitcoin-qt is not necessary

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ apps:
       # https://docs.snapcraft.io/environment-variables/7983
       HOME: $SNAP_USER_COMMON
   qt:
-    command: bin/desktop-launch bin/bitcoin-qt
+    command: bin/desktop-launch bitcoin-qt
     plugs: [home, removable-media, network, network-bind, desktop, x11, unity7]
     environment:
       HOME: $SNAP_USER_COMMON


### PR DESCRIPTION
The bin/ path is only needed for the command that will be executed, not the argument to the command. Since the command for qt is actually bin/desktop-launch, there is no need to do the same for its bitcoin-qt argument.

The bitcoin-core.qt in the current 28.x/edge build (build 176) does not work because of this issue.