### PR TITLE
snap: Drop `desktop-launch`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,11 +22,10 @@ apps:
       # https://docs.snapcraft.io/environment-variables/7983
       HOME: $SNAP_USER_COMMON
   qt:
-    command: bin/desktop-launch bitcoin-qt
+    command: bin/bitcoin-qt
     plugs: [home, removable-media, network, network-bind, desktop, x11, unity7]
     environment:
       HOME: $SNAP_USER_COMMON
-      DISABLE_WAYLAND: 1
   cli:
     command: bin/bitcoin-cli
     plugs: [home, removable-media, network]
@@ -47,39 +46,9 @@ apps:
       HOME: $SNAP_USER_COMMON
 
 parts:
-  # Needed to supply desktop-launch
-  # Paste from https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml
-  # Boilerplate seems to be required according to https://bugs.launchpad.net/snapcraft/+bug/1800057
-  desktop-qt5:
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-depth: 1
-    source-subdir: qt
-    source-commit: ec861254c2a1d2447b2c589446e6cdf04c75c260
-    plugin: make
-    make-parameters: ["FLAVOR=qt5"]
-    build-packages:
-      - build-essential
-      - qtbase5-dev
-      - dpkg-dev
-    stage-packages:
-      - libxkbcommon0
-      - ttf-ubuntu-font-family
-      - dmz-cursor-theme
-      - light-themes
-      - adwaita-icon-theme
-      - gnome-themes-standard
-      - shared-mime-info
-      - libqt5gui5
-      - libgdk-pixbuf2.0-0
-      - libqt5svg5 # for loading icon themes which are svg
-      - try: [appmenu-qt5] # not available on core18
-      - locales-all
-      - xdg-user-dirs
-      - fcitx-frontend-qt5
-
   bitcoin-core:
     plugin: nil
-    override-build: | 
+    override-build: |
       env | grep SNAP
       wget https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/SHA256SUMS
       wget https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}.tar.gz
@@ -100,5 +69,21 @@ parts:
       install -m 0644 -D -t $SNAPCRAFT_PART_INSTALL/share/pixmaps bitcoin128.png
     build-packages:
       - wget
-    after:
-      - desktop-qt5
+    stage-packages:
+      - libxcb1
+      - libxkbcommon0
+      - libxkbcommon-x11-0
+      - libfontconfig1
+      - libfreetype6
+      - libxcb-icccm4
+      - libxcb-image0
+      - libxcb-shm0
+      - libxcb-keysyms1
+      - libxcb-randr0
+      - libxcb-render-util0
+      - libxcb-render0
+      - libxcb-shape0
+      - libxcb-sync1
+      - libxcb-xfixes0
+      - libxcb-xinerama0
+      - libxcb-xkb1


### PR DESCRIPTION
Since commit f2ec0873debe0e17a3225aac9d6b8d4337593232, which replaced building dynamically linked binaries with downloading statically linked release binaries, there's no longer a need to prepare the environment (e.g. Qt plugin paths). We now only need to ensure required shared libraries are present at runtime.

This PR removes the `desktop-launch` helper, facilitating the update to v30.0 with Qt 6.