### PR TITLE
ci: Avoid separate pull to work around snap issue

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,5 @@ task:
     - snap install snapcraft --classic
     - snap install lxd
     - /snap/bin/lxd init --auto
-  snapcraft_pull_script:
-    - snapcraft pull --use-lxd
-  ci_script:
+  snapcraft_build_script:
     - snapcraft --use-lxd


### PR DESCRIPTION
Work around https://github.com/canonical/snapcraft/issues/5316

https://cirrus-ci.com/task/6347928203165696?logs=ci#L0:

```
...
snapcraft --use-lxd
Launching a container.
Waiting for container to be ready
Waiting for network to be ready...
error: cannot perform the following tasks:
- Run configure hook of "core" snap (run hook "configure": cannot set "core.experimental.snapd-snap": unsupported system option)
An error occurred when trying to execute 'snap set system experimental.snapd-snap=true' with 'LXD': returned exit code 1.
Exit status: 2