### PR TITLE
snap: Enable `kde-neon` extension

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,9 +23,13 @@ apps:
       HOME: $SNAP_USER_COMMON
   qt:
     command: bin/bitcoin-qt
+    extensions: [kde-neon]
     plugs: [home, removable-media, network, network-bind, desktop, x11, unity7]
     environment:
       HOME: $SNAP_USER_COMMON
+      # https://forum.snapcraft.io/t/kde-neon-6-extension-snap-qt-qpa-platform-overwritten/46054
+      WAYLAND_DISPLAY: unset
+      QT_QPA_PLATFORM: xcb
   cli:
     command: bin/bitcoin-cli
     plugs: [home, removable-media, network]


### PR DESCRIPTION
This PR is an amendment to https://github.com/bitcoin-core/packaging/pull/276, which was incomplete and caused some [issues](https://github.com/bitcoin-core/packaging/pull/276#issuecomment-3018444835).

According to the Snapcraft documentation, the use of [`snapcraft-desktop-helpers`](https://github.com/ubuntu/snapcraft-desktop-helpers/), which was removed in https://github.com/bitcoin-core/packaging/pull/276, has been [deprecated](https://forum.snapcraft.io/t/desktop-applications/13034) in favor of the [`kde-neon`](https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/kde-neon-extensions/) extension.

This PR addresses the resulting issue.

For Bitcoin Core v30.0 using Qt 6, the following diff should be applied:
```diff
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
 
 grade: stable
 confinement: strict
-base: core20
+base: core22
 
 apps:
   daemon:
@@ -23,7 +23,7 @@ apps:
       HOME: $SNAP_USER_COMMON
   qt:
     command: bin/bitcoin-qt
-    extensions: [kde-neon]
+    extensions: [kde-neon-6]
     plugs: [home, removable-media, network, network-bind, desktop, x11, unity7]
     environment:
       HOME: $SNAP_USER_COMMON
```

It remains unclear how to correctly handle the application icon in some desktop environments or UI components, such as Ubuntu Dock.