### PR TITLE
snap: Use core22

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,5 +10,7 @@ task:
     - snap install snapcraft --classic
     - snap install lxd
     - /snap/bin/lxd init --auto
-  snapcraft_build_script:
+  snapcraft_pull_script:
+    - snapcraft pull --use-lxd
+  ci_script:
     - snapcraft --use-lxd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,9 +50,9 @@ parts:
     plugin: nil
     override-build: |
       env | grep SNAP
-      wget https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/SHA256SUMS
-      wget https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}.tar.gz
-      wget https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
+      curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/SHA256SUMS
+      curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}.tar.gz
+      curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
       echo "94ec151f452a221393d08f6b02fb30baacbeb59f194611f49069e7f5509b46fe  SHA256SUMS" | sha256sum --check
       sha256sum --ignore-missing --check SHA256SUMS
       tar -xvf bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
@@ -65,10 +65,10 @@ parts:
       install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-tx
       install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-wallet
       install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-util
-      wget https://raw.githubusercontent.com/bitcoin/bitcoin/v${SNAPCRAFT_PROJECT_VERSION}/share/pixmaps/bitcoin128.png
+      curl -LO https://raw.githubusercontent.com/bitcoin/bitcoin/v${SNAPCRAFT_PROJECT_VERSION}/share/pixmaps/bitcoin128.png
       install -m 0644 -D -t $SNAPCRAFT_PART_INSTALL/share/pixmaps bitcoin128.png
     build-packages:
-      - wget
+      - curl
     stage-packages:
       - libxcb1
       - libxkbcommon0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
 
 grade: stable
 confinement: strict
-base: core20
+base: core22
 
 apps:
   daemon:


### PR DESCRIPTION
While `core20` is still technically supported, it requires workarounds such as https://github.com/bitcoin-core/packaging/pull/284 to work around bugs like https://github.com/canonical/snapcraft/issues/5316.

Also, the kde-neon extension is only offered in an older version. kde-neon-6 isn't offered at all. Ref: https://github.com/bitcoin-core/packaging/pull/292

So just use `core22`.

My understanding is that even `core24` can be used, without any visible or breaking change to end-users, but this is left for a follow-up for now.

(Edit: The curl change isn't needed here, but should make future core updates easier)