### PR TITLE
Revert "snap: Enable `kde-neon` extension" and "snap: Drop `desktop-launch`"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,10 +22,11 @@ apps:
       # https://docs.snapcraft.io/environment-variables/7983
       HOME: $SNAP_USER_COMMON
   qt:
-    command: bin/bitcoin-qt
+    command: bin/desktop-launch bitcoin-qt
     plugs: [home, removable-media, network, network-bind, desktop, x11, unity7]
     environment:
       HOME: $SNAP_USER_COMMON
+      DISABLE_WAYLAND: 1
   cli:
     command: bin/bitcoin-cli
     plugs: [home, removable-media, network]
@@ -46,6 +47,35 @@ apps:
       HOME: $SNAP_USER_COMMON
 
 parts:
+  # Needed to supply desktop-launch
+  # Paste from https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml
+  # Boilerplate seems to be required according to https://bugs.launchpad.net/snapcraft/+bug/1800057
+  desktop-qt5:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-depth: 1
+    source-subdir: qt
+    source-commit: ec861254c2a1d2447b2c589446e6cdf04c75c260
+    plugin: make
+    make-parameters: ["FLAVOR=qt5"]
+    build-packages:
+      - build-essential
+      - qtbase5-dev
+      - dpkg-dev
+    stage-packages:
+      - libxkbcommon0
+      - fonts-ubuntu
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libqt5gui5
+      - libgdk-pixbuf2.0-0
+      - libqt5svg5 # for loading icon themes which are svg
+      - locales-all
+      - xdg-user-dirs
+      - fcitx-frontend-qt5
+
   bitcoin-core:
     plugin: nil
     override-build: |
@@ -69,21 +99,5 @@ parts:
       install -m 0644 -D -t $SNAPCRAFT_PART_INSTALL/share/pixmaps bitcoin128.png
     build-packages:
       - curl
-    stage-packages:
-      - libxcb1
-      - libxkbcommon0
-      - libxkbcommon-x11-0
-      - libfontconfig1
-      - libfreetype6
-      - libxcb-icccm4
-      - libxcb-image0
-      - libxcb-shm0
-      - libxcb-keysyms1
-      - libxcb-randr0
-      - libxcb-render-util0
-      - libxcb-render0
-      - libxcb-shape0
-      - libxcb-sync1
-      - libxcb-xfixes0
-      - libxcb-xinerama0
-      - libxcb-xkb1
+    after:
+      - desktop-qt5


### PR DESCRIPTION
The `kde-neon` extension is unavailable on Launchpad for architectures other than amd64. Reverting it lets us be able to build again.

`desktop-launch` is needed following the `kde-neon` revert to restore the behavior that `kde-neon` was doing. This revert is unclean and a few packages needed to be changed to work with the `core22` base.

Ideally we would have CI detect when launchpad would fail, but I'm not sure that that's possible, unless we make launchpad part of CI.

A possible alternative to reverting these is to cross build the snaps from a x86_64 machine and upload those to the store, but I can't figure out how to make Launchpad do that. It seems to only do native builds. In my testing, a cross build is able to produce the snaps, although I did not verify if those snaps worked.

Fixes #297 