### PR TITLE
snap: Enable cross-compiling on `amd64` and `arm64`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,7 +53,7 @@ parts:
   bitcoin-core:
     plugin: nil
     override-build: |
-      env | grep SNAP
+      env | grep "CRAFT\|SNAP" | sort
       curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/SHA256SUMS
       curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}.tar.gz
       curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,22 +54,23 @@ parts:
     plugin: nil
     override-build: |
       env | grep "CRAFT\|SNAP" | sort
-      curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/SHA256SUMS
-      curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}.tar.gz
-      curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${CRAFT_ARCH_TRIPLET_BUILD_FOR}.tar.gz
+      bitcoin_core_version=$(craftctl get version)
+      curl -LO https://bitcoincore.org/bin/bitcoin-core-${bitcoin_core_version}/SHA256SUMS
+      curl -LO https://bitcoincore.org/bin/bitcoin-core-${bitcoin_core_version}/bitcoin-${bitcoin_core_version}.tar.gz
+      curl -LO https://bitcoincore.org/bin/bitcoin-core-${bitcoin_core_version}/bitcoin-${bitcoin_core_version}-${CRAFT_ARCH_TRIPLET_BUILD_FOR}.tar.gz
       echo "94ec151f452a221393d08f6b02fb30baacbeb59f194611f49069e7f5509b46fe  SHA256SUMS" | sha256sum --check
       sha256sum --ignore-missing --check SHA256SUMS
-      tar -xvf bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${CRAFT_ARCH_TRIPLET_BUILD_FOR}.tar.gz
-      tar -xvf bitcoin-${SNAPCRAFT_PROJECT_VERSION}.tar.gz
+      tar -xvf bitcoin-${bitcoin_core_version}-${CRAFT_ARCH_TRIPLET_BUILD_FOR}.tar.gz
+      tar -xvf bitcoin-${bitcoin_core_version}.tar.gz
       echo "Running tests ..."
-      bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/test_bitcoin
-      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoind
-      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-qt
-      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-cli
-      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-tx
-      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-wallet
-      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-util
-      curl -LO https://raw.githubusercontent.com/bitcoin/bitcoin/v${SNAPCRAFT_PROJECT_VERSION}/share/pixmaps/bitcoin128.png
+      bitcoin-${bitcoin_core_version}/bin/test_bitcoin
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${bitcoin_core_version}/bin/bitcoind
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${bitcoin_core_version}/bin/bitcoin-qt
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${bitcoin_core_version}/bin/bitcoin-cli
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${bitcoin_core_version}/bin/bitcoin-tx
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${bitcoin_core_version}/bin/bitcoin-wallet
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${bitcoin_core_version}/bin/bitcoin-util
+      curl -LO https://raw.githubusercontent.com/bitcoin/bitcoin/v${bitcoin_core_version}/share/pixmaps/bitcoin128.png
       install -m 0644 -D -t $CRAFT_PART_INSTALL/share/pixmaps bitcoin128.png
     build-packages:
       - curl

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,17 @@ description: |
 grade: stable
 confinement: strict
 base: core22
+architectures:
+  - build-on: [amd64, arm64]
+    build-for: [amd64]
+  - build-on: [amd64, arm64]
+    build-for: [arm64]
+  - build-on: [amd64, arm64, armhf]
+    build-for: [armhf]
+  - build-on: [amd64, arm64, ppc64el]
+    build-for: [ppc64el]
+  - build-on: [amd64, arm64, riscv64]
+    build-for: [riscv64]
 
 apps:
   daemon:
@@ -62,8 +73,12 @@ parts:
       sha256sum --ignore-missing --check SHA256SUMS
       tar -xvf bitcoin-${bitcoin_core_version}-${CRAFT_ARCH_TRIPLET_BUILD_FOR}.tar.gz
       tar -xvf bitcoin-${bitcoin_core_version}.tar.gz
-      echo "Running tests ..."
-      bitcoin-${bitcoin_core_version}/bin/test_bitcoin
+      if [ "$CRAFT_ARCH_TRIPLET_BUILD_ON" != "$CRAFT_ARCH_TRIPLET_BUILD_FOR" ]; then
+        echo "Skipping tests when cross-compiling."
+      else
+        echo "Running tests ..."
+        bitcoin-${bitcoin_core_version}/bin/test_bitcoin
+      fi
       install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${bitcoin_core_version}/bin/bitcoind
       install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${bitcoin_core_version}/bin/bitcoin-qt
       install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${bitcoin_core_version}/bin/bitcoin-cli

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,21 +56,21 @@ parts:
       env | grep "CRAFT\|SNAP" | sort
       curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/SHA256SUMS
       curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}.tar.gz
-      curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
+      curl -LO https://bitcoincore.org/bin/bitcoin-core-${SNAPCRAFT_PROJECT_VERSION}/bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${CRAFT_ARCH_TRIPLET_BUILD_FOR}.tar.gz
       echo "94ec151f452a221393d08f6b02fb30baacbeb59f194611f49069e7f5509b46fe  SHA256SUMS" | sha256sum --check
       sha256sum --ignore-missing --check SHA256SUMS
-      tar -xvf bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
+      tar -xvf bitcoin-${SNAPCRAFT_PROJECT_VERSION}-${CRAFT_ARCH_TRIPLET_BUILD_FOR}.tar.gz
       tar -xvf bitcoin-${SNAPCRAFT_PROJECT_VERSION}.tar.gz
       echo "Running tests ..."
       bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/test_bitcoin
-      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoind
-      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-qt
-      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-cli
-      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-tx
-      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-wallet
-      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-util
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoind
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-qt
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-cli
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-tx
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-wallet
+      install -m 0755 -D -t $CRAFT_PART_INSTALL/bin bitcoin-${SNAPCRAFT_PROJECT_VERSION}/bin/bitcoin-util
       curl -LO https://raw.githubusercontent.com/bitcoin/bitcoin/v${SNAPCRAFT_PROJECT_VERSION}/share/pixmaps/bitcoin128.png
-      install -m 0644 -D -t $SNAPCRAFT_PART_INSTALL/share/pixmaps bitcoin128.png
+      install -m 0644 -D -t $CRAFT_PART_INSTALL/share/pixmaps bitcoin128.png
     build-packages:
       - curl
     stage-packages:


### PR DESCRIPTION
This PR simplifies local testing of changes for Qt 6 on multiple platforms.

Based on https://github.com/bitcoin-core/packaging/pull/304.